### PR TITLE
docs(ru): sync Russian translation with English README

### DIFF
--- a/lang/russian.md
+++ b/lang/russian.md
@@ -1,138 +1,74 @@
 # Полный список значков и достижений на GitHub
 
-_Этот файл доступен на [других языках](../README.md)._
+_Читать на [других языках](../README.md)._
 
 <br>
 
-|                                 Значок                                 | Название                          | Можно получить?       | Как получить?                                                                                                                                                                               |
-|:----------------------------------------------------------------------:|-----------------------------------|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   ![Значок за достижение Heart On Your Sleeve][heart-on-your-sleeve]   | **Heart On Your Sleeve**          | Проходит тестирование | Отреагируйте на что-либо на GitHub с помощью эмодзи ❤️.                                                                                                                                     |
-|         ![Значок за достижение Open Sourcerer][open-sourcerer]         | **Open Sourcerer**                | Проходит тестирование | Вы сделали PR в несколько общедоступных репозиториев и эти PR были смёржены.                                                                                                                |
-|             ![Значок за достижение Starstruck][starstruck]             | **Starstruck**                    | Да                    | Созданный вами репозиторий должен получить <span class="fw-bold">16 звёзд</span> или больше.                                                                                                |
-|              ![Значок за достижение Quickdraw][quickdraw]              | **Quickdraw**                     | Да                    | Выдаётся, если вы хотя бы один раз закрыли `issue` или смёржили `pull request` <span class="fw-bold">в течение 5 минут</span> после открытия.                                               |
-|    ![Значок за достижение Pair Extraordinaire][pair-extraordinaire]    | **Pair Extraordinaire**           | Да                    | Был смёржен один или несколько `pull request`, который вы делали в соавторстве с другими разработчиками.                                                                                    |
-|             ![Значок за достижение Pull Shark][pull-shark]             | **Pull Shark**                    | Да                    | Было принято (смёржено) два открытых вами `pull request`-а (или больше).                                                                                                                    |
-|           ![Значок за достижение Galaxy Brain][galaxy-brain]           | **Galaxy Brain**                  | Да                    | Автор дискуссии (кроме раздела Community) принял два (или больше) ваших ответа (нажал `Mark as answer`).                                                                                    |
-|                   ![Значок за достижение YOLO][yolo]                   | **YOLO**                          | Да                    | Выдаётся, если хотя бы один ваш `pull request` был принят без замечаний (автор не написал ни одного треда и смёржил правки).                                                                |
-|         ![Значок за достижение Public Sponsor][public-sponsor]         | **Public Sponsor**                | Да                    | Выдаётся, если вы хотя бы один раз спонсировали opensource-проект или разработчика на GitHub.                                                                                               |
-|        ![Значок за достижение Mars 2020 Contributor][mars-2020]        | **Mars 2020 Contributor**         | Нет                   | Сделали вклад в один из репозиториев проекта [Mars 2020 Helicopter Mission](https://github.com/readme/featured/nasa-ingenuity-helicopter). Выдавался за хотя бы 1 случай вклада. |
-| ![Значок за достижение 2020 GitHub Archive Program][arctic-code-vault] | **Arctic Code Vault Contributor** | Нет                   | Ваш код был включён в программу <a href="https://archiveprogram.github.com">2020 GitHub Archive Program</a>. Выдавался за хотя бы 1 случай вклада.                                          |
-
-<!-- Значки не имеющие градаций по уровням -->
-[starstruck]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default.png
-[quickdraw]: https://github.githubassets.com/images/modules/profile/achievements/quickdraw-default.png
-[pair-extraordinaire]: https://github.githubassets.com/images/modules/profile/achievements/pair-extraordinaire-default.png
-[pull-shark]: https://github.githubassets.com/images/modules/profile/achievements/pull-shark-default.png
-[galaxy-brain]: https://github.githubassets.com/images/modules/profile/achievements/galaxy-brain-default.png
-[yolo]: https://github.githubassets.com/images/modules/profile/achievements/yolo-default.png
-[public-sponsor]: https://github.githubassets.com/images/modules/profile/achievements/public-sponsor-default.png
-[mars-2020]: https://github.githubassets.com/images/modules/profile/achievements/mars-2020-contributor-default.png
-[arctic-code-vault]: https://github.githubassets.com/images/modules/profile/achievements/arctic-code-vault-contributor-default.png
-[heart-on-your-sleeve]: https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-default.png
-[open-sourcerer]: https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-default.png
+| Значок | Название | Как получить |
+| :---: | --- | --- |
+| ![Значок Heart On Your Sleeve](https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-default.png) | **Heart On Your Sleeve** | Отреагируйте на что-либо на GitHub эмодзи ❤️ **(в тестировании — сейчас нельзя получить)** |
+| ![Значок Open Sourcerer](https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-default.png) | **Open Sourcerer** | Ваши PR были смёржены в нескольких публичных репозиториях **(в тестировании — сейчас нельзя получить)** |
+| ![Значок Starstruck](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default.png) | **Starstruck** | Создайте репозиторий с **16 звёздами** или [больше](#градация-некоторых-достижений). |
+| ![Значок Quickdraw](https://github.githubassets.com/images/modules/profile/achievements/quickdraw-default.png) | **Quickdraw** | Закройте issue или pull request **в течение 5 минут** после открытия. |
+| ![Значок Pair Extraordinaire](https://github.githubassets.com/images/modules/profile/achievements/pair-extraordinaire-default.png) | **Pair Extraordinaire** | Станьте соавтором (**co-authored**) в **одном** или [больше](#градация-некоторых-достижений) смёрженных pull request. |
+| ![Значок Pull Shark](https://github.githubassets.com/images/modules/profile/achievements/pull-shark-default.png) | **Pull Shark** | **2 pull request** смёржены (или [больше](#градация-некоторых-достижений)). |
+| ![Значок Galaxy Brain](https://github.githubassets.com/images/modules/profile/achievements/galaxy-brain-default.png) | **Galaxy Brain** | **2 принятых ответа** или [больше](#градация-некоторых-достижений). *С 2024 года не засчитывается в [Community Discussions](https://github.com/orgs/community/discussions/) — подробнее [здесь](https://github.com/orgs/community/discussions/106536).* |
+| ![Значок YOLO](https://github.githubassets.com/images/modules/profile/achievements/yolo-default.png) | **YOLO** | Смержите **хотя бы один** pull request **без code review**. |
+| ![Значок Public Sponsor](https://github.githubassets.com/images/modules/profile/achievements/public-sponsor-default.png) | **Public Sponsor** | Станьте публичным спонсором через [GitHub Sponsors](https://github.com/sponsors). |
+| ![Значок Mars 2020 Contributor](https://github.githubassets.com/images/modules/profile/achievements/mars-2020-contributor-default.png) | **Mars 2020 Contributor** | Внесли код в репозитории [миссии Mars 2020 Helicopter](https://github.com/readme/featured/nasa-ingenuity-helicopter). *Сейчас нельзя получить.* |
+| ![Значок Arctic Code Vault Contributor](https://github.githubassets.com/images/modules/profile/achievements/arctic-code-vault-contributor-default.png) | **Arctic Code Vault Contributor** | Внесли код в репозиторий программы [2020 GitHub Archive Program](https://archiveprogram.github.com/). *Сейчас нельзя получить.* |
 
 <br>
 
 ## Градация некоторых достижений
 
-Для получения большинства значков необходимо произвести некоторое действие однократно, но в ряде случаев действие
-необходимо произвести несколько раз.
+У части достижений есть не только базовый уровень, но и ступени (tiers).
 
-| Достижение               |       По-умолчанию        |      Бронзовый      |     Серебряный      |        Золотой        |
-|:-------------------------|:-------------------------:|:-------------------:|:-------------------:|:---------------------:|
-| **Starstruck**           |      ![][starstruck]      |   ![][ss-bronze]    |   ![][ss-silver]    |     ![][ss-gold]      |
-|                          |     [16 stars][ss-16]     | [128 stars][ss-128] | [512 stars][ss-512] | [4096 stars][ss-4096] |
-| **Pair Extraordinaire**  | ![][pair-extraordinaire]  |   ![][pe-bronze]    |   ![][pe-silver]    |     ![][pe-gold]      |
-|                          |       [1 PR][pe-1]        |   [10 PR][pe-10]    |   [24 PR][pe-24]    |    [48 PR][pe-48]     |
-| **Pull Shark**           |      ![][pull-shark]      |   ![][ps-bronze]    |   ![][ps-silver]    |     ![][ps-gold]      |
-|                          |       [2 PR][ps-2]        |  16 pull requests   |  128 pull requests  |  [1024 PR][ps-1024]   |
-| **Galaxy Brain**         |     ![][galaxy-brain]     |   ![][gb-bronze]    |   ![][gb-silver]    |     ![][gb-gold]      |
-|                          |     [2 answers][gb-2]     |      8 answers      |     16 answers      |  [32 answers][gb-32]  |
-| **Heart On Your Sleeve** | ![][heart-on-your-sleeve] |  ![][hoys-bronze]   |  ![][hoys-silver]   |    ![][hoys-gold]     | 
-|                          |            ???            |         ???         |         ???         |          ???          |
-| **Open Sourcerer**       |    ![][open-sourcerer]    |   ![][os-bronze]    |   ![][os-silver]    |     ![][os-gold]      | 
-|                          |            ???            |         ???         |         ???         |          ???          |
+| Достижение | По умолчанию | Бронзовый | Серебряный | Золотой |
+| --- | :---: | :---: | :---: | :---: |
+| **Starstruck** | ![Starstruck](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default.png) | ![Bronze](https://github.githubassets.com/images/modules/profile/achievements/starstruck-bronze.png) | ![Silver](https://github.githubassets.com/images/modules/profile/achievements/starstruck-silver.png) | ![Gold](https://github.githubassets.com/images/modules/profile/achievements/starstruck-gold.png) |
+| | 16 звёзд | 128 звёзд [@gomzyakov](https://github.com/gomzyakov?achievement=starstruck&tab=achievements) | 512 звёзд | 4096 звёзд [@torvalds](https://github.com/torvalds?achievement=starstruck&tab=achievements) |
+| **Pair Extraordinaire** | ![Pair Extraordinaire][pe-default] | ![Bronze][pe-bronze] | ![Silver][pe-silver] | ![Gold][pe-gold] |
+| | 1 PR [@gomzyakov](https://github.com/gomzyakov?achievement=pair-extraordinaire&tab=achievements) | 10 PR | 24 PR | 48 PR [@Rongronggg9](https://github.com/Rongronggg9?achievement=pair-extraordinaire&tab=achievements) |
+| **Pull Shark** | ![Pull Shark][ps-default] | ![Bronze][ps-bronze] | ![Silver][ps-silver] | ![Gold][ps-gold] |
+| | 2 PR [@gomzyakov](https://github.com/gomzyakov?achievement=pull-shark&tab=achievements) | 16 PR | 128 PR | 1024 PR [@ljharb](https://github.com/ljharb?achievement=pull-shark&tab=achievements) |
+| **Galaxy Brain** | ![Galaxy Brain][gb-default] | ![Bronze][gb-bronze] | ![Silver][gb-silver] | ![Gold][gb-gold] |
+| | 2 ответа | 8 ответов | 16 ответов | 32 ответа [@ljharb](https://github.com/ljharb?achievement=galaxy-brain&tab=achievements) |
+| **Heart On Your Sleeve** | ![Heart On Your Sleeve](https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-default.png) | ![Bronze](https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-bronze.png) | ![Silver](https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-silver.png) | ![Gold](https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-gold.png) |
+| | ??? | ??? | ??? | ??? |
+| **Open Sourcerer** | ![Open Sourcerer](https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-default.png) | ![Bronze](https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-bronze.png) | ![Silver](https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-silver.png) | ![Gold](https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-gold.png) |
+| | ??? | ??? | ??? | ??? |
 
-Все остальные значки на GitHub даются за однократное выполнение условий.
-
-<!-- Градации значков Starstruck -->
-[ss-bronze]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-bronze.png
-[ss-silver]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-silver.png
-[ss-gold]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-gold.png
-
-<!-- Ссылки на пользователей, получивших достижение Starstruck разных уровней -->
-[ss-16]: https://github.com/gomzyakov?achievement=starstruck&tab=achievements
-[ss-128]: https://github.com/smartschat?achievement=starstruck&tab=achievements
-[ss-512]: https://github.com/nolanlawson?achievement=starstruck&tab=achievements
-[ss-4096]: https://github.com/torvalds?achievement=starstruck&tab=achievements
-
-<!-- Градации значков Pair Extraordinaire -->
+[pe-default]: https://github.githubassets.com/images/modules/profile/achievements/pair-extraordinaire-default.png
 [pe-bronze]: https://github.githubassets.com/images/modules/profile/achievements/pair-extraordinaire-bronze.png
 [pe-silver]: https://github.githubassets.com/images/modules/profile/achievements/pair-extraordinaire-silver.png
 [pe-gold]: https://github.githubassets.com/images/modules/profile/achievements/pair-extraordinaire-gold.png
 
-<!-- Ссылки на пользователей, получивших достижение Pair Extraordinaire разных уровней -->
-[pe-1]: https://github.com/gomzyakov?achievement=pair-extraordinaire&tab=achievements
-[pe-10]: https://github.com/jecisc?tab=achievements&achievement=pair-extraordinaire
-[pe-24]: https://github.com/37108?achievement=pair-extraordinaire&tab=achievements
-[pe-48]: https://github.com/Rongronggg9?achievement=pair-extraordinaire&tab=achievements
-
-<!-- Градации значков Pull Shark -->
+[ps-default]: https://github.githubassets.com/images/modules/profile/achievements/pull-shark-default.png
 [ps-bronze]: https://github.githubassets.com/images/modules/profile/achievements/pull-shark-bronze.png
 [ps-silver]: https://github.githubassets.com/images/modules/profile/achievements/pull-shark-silver.png
 [ps-gold]: https://github.githubassets.com/images/modules/profile/achievements/pull-shark-gold.png
 
-<!-- Ссылки на пользователей, получивших достижение Pull Shark разных уровней -->
-[ps-2]: https://github.com/gomzyakov?tab=achievements&achievement=pull-shark
-<!-- 16 pull requests - у кого есть? --> 
-<!-- 128 pull requests - у кого есть? -->
-[ps-1024]: https://github.com/ljharb?achievement=pull-shark&tab=achievements
-
-<!-- Градации значков Galaxy Brain -->
+[gb-default]: https://github.githubassets.com/images/modules/profile/achievements/galaxy-brain-default.png
 [gb-bronze]: https://github.githubassets.com/images/modules/profile/achievements/galaxy-brain-bronze.png
 [gb-silver]: https://github.githubassets.com/images/modules/profile/achievements/galaxy-brain-silver.png
 [gb-gold]: https://github.githubassets.com/images/modules/profile/achievements/galaxy-brain-gold.png
 
-<!-- Ссылки на пользователей, получивших достижение Galaxy Brain разных уровней -->
-[gb-2]: https://github.com/gomzyakov?tab=achievements&achievement=galaxy-brain
-<!-- 8 answers - у кого есть? --> 
-<!-- 16 answers - у кого есть? -->
-[gb-32]: https://github.com/ljharb?achievement=galaxy-brain&tab=achievements
+<br>
 
-<!-- Градации значков Heart On Your Sleeve -->
-[hoys-bronze]: https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-bronze.png
-[hoys-silver]: https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-silver.png
-[hoys-gold]: https://github.githubassets.com/images/modules/profile/achievements/heart-on-your-sleeve-gold.png
+## Тон кожи Emoji в значках
 
-<!-- Градации значков Open Sourcerer -->
-[os-bronze]: https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-bronze.png
-[os-silver]: https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-silver.png
-[os-gold]: https://github.githubassets.com/images/modules/profile/achievements/open-sourcerer-gold.png
+Внешний вид некоторых значков зависит от настройки **тона кожи Emoji**.
+
+Изменить можно в [настройках внешнего вида](https://github.com/settings/appearance).
 
 <br>
 
-## Цвет значков и тон Emoji
+| **Значок** | 👋 | 👋🏻 | 👋🏼 | 👋🏽 | 👋🏾 | 👋🏿 |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Starstruck** | ![Default](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default.png) | ![Light](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--light.png) | ![Light-medium](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--light-medium.png) | ![Medium](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--medium.png) | ![Medium-dark](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--medium-dark.png) | ![Dark](https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--dark.png) |
+| **Quickdraw** | ![Default][q-default] | ![Light][q-light] | ![Light-medium][q-light-medium] | ![Medium][q-medium] | ![Medium-dark][q-medium-dark] | ![Dark][q-dark] |
 
-Внешний вид некоторых значков зависит от предпочитаемого вами тона кожи Emoji.
-
-Вы можете изменить предпочитаемый тон кожи, перейдя в [Настройки внешнего вида](https://github.com/settings/appearance).
-
-<br>
-
-| **Badge**      |       👋       |     👋🏻     |        👋🏼         |     👋🏽      |        👋🏾        |    👋🏿     |
-|----------------|:--------------:|:------------:|:-------------------:|:-------------:|:------------------:|:-----------:|
-| **Starstruck** | ![][s-default] | ![][s-light] | ![][s-light-medium] | ![][s-medium] | ![][s-medium-dark] | ![][s-dark] |
-| **Quickdraw**  | ![][q-default] | ![][q-light] | ![][q-light-medium] | ![][q-medium] | ![][q-medium-dark] | ![][q-dark] |
-
-<!-- Ссылки на зветовые вариации значков Starstruck -->
-[s-default]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default.png
-[s-light]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--light.png
-[s-light-medium]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--light-medium.png
-[s-medium]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--medium.png
-[s-medium-dark]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--medium-dark.png
-[s-dark]: https://github.githubassets.com/images/modules/profile/achievements/starstruck-default--dark.png
-
-<!-- Ссылки на зветовые вариации значков Quickdraw -->
 [q-default]: https://github.githubassets.com/images/modules/profile/achievements/quickdraw-default.png
 [q-light]: https://github.githubassets.com/images/modules/profile/achievements/quickdraw-default--light.png
 [q-light-medium]: https://github.githubassets.com/images/modules/profile/achievements/quickdraw-default--light-medium.png
@@ -142,35 +78,20 @@ _Этот файл доступен на [других языках](../README.m
 
 <br>
 
-## Другие значки на GitHub
+## Значки Highlights
 
-| Значок                         | Название                       | Можно ли получить? | Как получить?                                                                                                                                        |
-|--------------------------------|--------------------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][gp-dark] ![][gp-light]     | **Pro**                        | Да                 | Используйте тарифный план [GitHub Pro](https://docs.github.com/en/get-started/learning-about-github/githubs-products#github-pro)                     |                                                                                                 |
-| ![][dpm-dark] ![][dpm-light]   | **Developer Program Member**   | Да                 | Станьте зарегистрированным участником программы [GitHub Developer Program](https://docs.github.com/en/developers/overview/github-developer-program)  |
-| ![][sbbh-dark] ![][sbbh-light] | **Security Bug Bounty Hunter** | Да                 | Помогали в поиске уязвимостей на [GitHub Security](https://bounty.github.com/)                                                                       |
-| ![][gce-dark] ![][gce-light]   | **GitHub Campus Expert**       | Да                 | Принимали участие в [GitHub Campus Program](https://education.github.com/experts)                                                                    |
-| ![][SAC-dark] ![][SAC-light]   | **Security advisory credit**   | Да                 | Ваши рекомендации по безопасности были приняты в [GitHub Advisory Database](https://github.com/advisories)                                           |
-| ![][da-dark] ![][da-light]     | **Discussion answered**        | Нет                | Ваш ответ в дискуссиях был отмечен как правильный                                                                                                    |
-
-<!-- Другие значки на GitHub -->
-[gp-dark]: https://user-images.githubusercontent.com/65187002/173065531-57dbf8b1-7eb7-4d46-81bf-f2d18c7c9112.svg#gh-dark-mode-only
-[gp-light]: https://user-images.githubusercontent.com/65187002/173065669-d1fdb5a7-8895-43cc-8dea-72a511a37e86.svg#gh-light-mode-only
-[da-dark]: https://user-images.githubusercontent.com/65187002/173078083-15a75f15-b040-4a92-8d70-561a206d9fd9.svg#gh-dark-mode-only
-[da-light]: https://user-images.githubusercontent.com/65187002/173078083-15a75f15-b040-4a92-8d70-561a206d9fd9.svg#gh-light-mode-only
-[dpm-dark]: https://user-images.githubusercontent.com/65187002/173079579-3c393d22-7a13-4e7d-87b8-341fb613d52b.svg#gh-dark-mode-only
-[dpm-light]: https://user-images.githubusercontent.com/65187002/173079614-33f43a97-1cc2-4228-85e3-ef43836e17c2.svg#gh-light-mode-only
-[sbbh-dark]: https://user-images.githubusercontent.com/65187002/173081624-93e3cf1f-50b7-45a4-82b7-1954f66368b9.svg#gh-dark-mode-only
-[sbbh-light]: https://user-images.githubusercontent.com/65187002/173081624-93e3cf1f-50b7-45a4-82b7-1954f66368b9.svg#gh-light-mode-only
-[gce-dark]: https://user-images.githubusercontent.com/65187002/173082819-b3625c23-bfd6-4492-b828-56ed91c45f52.svg#gh-dark-mode-only
-[gce-light]: https://user-images.githubusercontent.com/65187002/173082836-08be81fe-13b7-4acf-9096-e5241d76f237.svg#gh-light-mode-only
-[SAC-dark]: https://user-images.githubusercontent.com/65187002/173084051-79a0a626-1c1a-4d60-afdf-50ad001d7b21.svg#gh-dark-mode-only
-[SAC-light]: https://user-images.githubusercontent.com/65187002/173084071-5f321da2-b2a9-490b-a524-1b21fa384d7e.svg#gh-light-mode-only
+| Значок | Название | Можно получить? | Как получить |
+| --- | --- | --- | --- |
+| ![GitHub Pro](https://user-images.githubusercontent.com/65187002/173065531-57dbf8b1-7eb7-4d46-81bf-f2d18c7c9112.svg#gh-dark-mode-only)![GitHub Pro](https://user-images.githubusercontent.com/65187002/173065669-d1fdb5a7-8895-43cc-8dea-72a511a37e86.svg#gh-light-mode-only) | **Pro** | Да | Подписка [GitHub Pro](https://docs.github.com/en/get-started/learning-about-github/githubs-products#github-pro) |
+| ![Developer Program](https://user-images.githubusercontent.com/65187002/173079579-3c393d22-7a13-4e7d-87b8-341fb613d52b.svg#gh-dark-mode-only)![Developer Program](https://user-images.githubusercontent.com/65187002/173079614-33f43a97-1cc2-4228-85e3-ef43836e17c2.svg#gh-light-mode-only) | **Developer Program Member** | Да | Участие в [GitHub Developer Program](https://docs.github.com/en/developers/overview/github-developer-program) |
+| ![Bug Bounty Hunter](https://user-images.githubusercontent.com/65187002/173081624-93e3cf1f-50b7-45a4-82b7-1954f66368b9.svg#gh-dark-mode-only)![Bug Bounty Hunter](https://user-images.githubusercontent.com/65187002/173081657-e500d72c-9247-44c2-a3d3-2deff30e1ae7.svg#gh-light-mode-only) | **Security Bug Bounty Hunter** | Да | Поиск уязвимостей в [GitHub Security](https://bounty.github.com/) |
+| ![Campus Expert](https://user-images.githubusercontent.com/65187002/173082819-b3625c23-bfd6-4492-b828-56ed91c45f52.svg#gh-dark-mode-only)![Campus Expert](https://user-images.githubusercontent.com/65187002/173082836-08be81fe-13b7-4acf-9096-e5241d76f237.svg#gh-light-mode-only) | **GitHub Campus Expert** | Да | Программа [GitHub Campus Experts](https://education.github.com/experts) |
+| ![Security Advisory](https://user-images.githubusercontent.com/65187002/173084051-79a0a626-1c1a-4d60-afdf-50ad001d7b21.svg#gh-dark-mode-only)![Security Advisory](https://user-images.githubusercontent.com/65187002/173084071-5f321da2-b2a9-490b-a524-1b21fa384d7e.svg#gh-light-mode-only) | **Security Advisory Credit** | Да | Принятый отчёт в [GitHub Advisory Database](https://github.com/advisories) |
+| | **GitHub Star** | Да | Стать [GitHub Star](https://stars.github.com) |
+| ![Discussion answered](https://user-images.githubusercontent.com/65187002/173078083-15a75f15-b040-4a92-8d70-561a206d9fd9.svg#gh-dark-mode-only)![Discussion answered](https://user-images.githubusercontent.com/65187002/173078106-28bea542-4620-46ee-837d-defda3e44ca6.svg#gh-light-mode-only) | **Discussion answered** | Нет | Ваш ответ в Discussions отмечен как принятый |
 
 <br>
 
 ## Есть предложения?
 
-Если у вас есть вопрос или предложение, как улучшить информацию на этой странице, вы всегда можете написать
-в [issues](https://github.com/gomzyakov/achievements/issues).
-
+Вопросы и идеи по улучшению — в [issues](https://github.com/gomzyakov/github-achievements/issues).


### PR DESCRIPTION
## Summary
- Sync `lang/russian.md` with the current English `README.md`
- Fix YOLO, Quickdraw, and Pair Extraordinaire descriptions
- Add note that Galaxy Brain no longer counts in GitHub Community Discussions
- Add GitHub Star to Highlights section
- Mark experimental/legacy badges as currently unobtainable

## Test plan
- [x] Markdown renders correctly
- [x] Links to badge tiers and external docs work